### PR TITLE
Prevent double click on accept enrol / unenroll buttons

### DIFF
--- a/enrol_into_course.php
+++ b/enrol_into_course.php
@@ -63,6 +63,7 @@ if ($total_places - $busy_places > 0) {
 
 	if (is_user_enrolled($userid, $courseid)) {
 		$enrol->send_confirmation_email($user, $courseid);
+		add_to_log($courseid, 'block_metacourse', 'add enrolment', 'blocks/metacourse/enrol_into_course.php', '$userid successfully enrolled');
 		redirect(new moodle_url($CFG->wwwroot."/blocks/metacourse/list_metacourses.php"), "You've been enrolled", 5);
 	} else {
 		add_to_log($courseid, 'block_metacourse', 'add enrolment', 'blocks/metacourse/enrol_into_course.php', "Tried to enrol $userid into course $courseid, but somehow that failed");

--- a/js/core.js
+++ b/js/core.js
@@ -153,6 +153,10 @@
 	});
 
 	$(document.body).on('click','#accept_enrol', function(e){
+		var $this = $(this);
+		$this.prop('disabled', true);
+		$this.siblings('input[name="cancel"]').prop('disabled', true);
+
 		enrolledCourse.closest('form').submit();
 	});
 
@@ -195,11 +199,6 @@
 		
 	});
 
-	$(document.body).on('click','#accept_unenrol', function(e){
-		enrolledCourse.closest('form').submit();
-	});
-
-
 	$(document.body).on('click','#lean_background_unenrol input[name="cancel"]', function(){
 		$('#lean_background_unenrol').hide();
 		$('#lean_background_unenrol input[name="accept_unenrol"]').prop('checked',false);
@@ -230,6 +229,10 @@
 	});
 
 	$(document.body).on('click','#accept_unenrol', function(e){
+		var $this = $(this);
+		$this.prop('disabled', true);
+		$this.siblings('input[name="cancel"]').prop('disabled', true);
+
 		enrolledCourse.closest('form').submit();
 	});
 


### PR DESCRIPTION
Couldn't reproduce with the latest changes from master. However, I noticed that the issue where the cancel for is submitted as soon as you accept the terms has been fixed.

I'm guessing the issue was that users would click ok, then click submit, which would submit the form twice. Or maybe they would just double click .... Anyway, I've disabled the buttons as soon as the user presses submit
