### PR TITLE
Appearently not all PHP versions likes a timezone offset when creating a...

### DIFF
--- a/view_metacourse.php
+++ b/view_metacourse.php
@@ -266,7 +266,15 @@ if ($metacourse) {
 			$start = "-";
 			$end = "-";
 		} else{
-			$timezone = new DateTimeZone($datecourse->timezone);
+			// http://stackoverflow.com/questions/11820718/convert-utc-offset-to-timezone-or-date
+			$dstInEffect = date('I', $datecourse->startdate) == '1';
+			$timezoneName = timezone_name_from_abbr(null, $datecourse->timezone * 3600, $dstInEffect); // At first, try to get the timezone with adjustment for DST
+			
+			if($timezoneName === false) {
+				$timezoneName = timezone_name_from_abbr(null, $datecourse->timezone * 3600, false); // If that fails, fall back to ignoring DST
+			}
+			
+			$timezone = new DateTimeZone($timezoneName);
 			$start = new DateTime(null, $timezone);
 			$start->setTimestamp($datecourse->startdate);
 			$start = $start->format("d M Y - h:i A");


### PR DESCRIPTION
... DateTimeZone

The code that worked fine on my computer did not work on prod ... So now we use the timezone offset to find a matching timezone string and format based on that. DST detecting is definitely not perfect, since every contry does not observe DST, not everyone changes at the same time, etc. etc.
